### PR TITLE
Added: support for passing builder options and sourceWidths as props

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,25 +164,27 @@ npm run storybook
 
 ### `Img`
 
-| property      | type | description |
-| ------------- | ---- | ----------- |
-| `client`      | [`SanityClient`](https://www.npmjs.com/package/@sanity/client) | Client instance to use when building image URLs |
-| `image`       | [`SanityImageSource`](https://www.npmjs.com/package/@sanity/image-url#imagesource) | A reference to a Sanity image asset. You can pass in any asset that is also supported by the [image() method of @sanity/image-url](https://www.npmjs.com/package/@sanity/image-url#imagesource). |
-| `aspectRatio` | <code>number &#124; null<code> | Aspect ratio (`height ÷ width`) to which the source image should be cropped, e.g. `9/16` or `0.5625` for a 16:9 image. If omitted or set to `null`, the intrinsic aspect ratio of the source will be used. |
-| `lqip`        | `boolean`| Set to `true` to use the image's [Low Quality Image Placeholder](https://www.sanity.io/docs/image-metadata#74bfd1db9b97) as a placeholder (via CSS `background-image`). Requires that `lqip` be enabled in the image field's `metadata` setting – I think this needs to be present at time of of upload, but maybe not in recent versions. |
-| `sizes`       | `string` | String to use for the rendered `<img>` element's [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) attribute. See example in **Usage** above. |
+| property         | type | description |
+| ---------------- | ---- | ----------- |
+| `client`         | [`SanityClient`](https://www.npmjs.com/package/@sanity/client) | Client instance to use when building image URLs |
+| `image`          | [`SanityImageSource`](https://www.npmjs.com/package/@sanity/image-url#imagesource) | A reference to a Sanity image asset. You can pass in any asset that is also supported by the [image() method of @sanity/image-url](https://www.npmjs.com/package/@sanity/image-url#imagesource). |
+| `aspectRatio`    | <code>number &#124; null<code> | Aspect ratio (`height ÷ width`) to which the source image should be cropped, e.g. `9/16` or `0.5625` for a 16:9 image. If omitted or set to `null`, the intrinsic aspect ratio of the source will be used. |
+| `lqip`           | `boolean`| Set to `true` to use the image's [Low Quality Image Placeholder](https://www.sanity.io/docs/image-metadata#74bfd1db9b97) as a placeholder (via CSS `background-image`). Requires that `lqip` be enabled in the image field's `metadata` setting – I think this needs to be present at time of of upload, but maybe not in recent versions. |
+| `sizes`          | `string` | String to use for the rendered `<img>` element's [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) attribute. See example in **Usage** above. |
+| `builderOptions` | [`ImageUrlBuilderOptionsWithAliases`](https://github.com/sanity-io/image-url/blob/v1.0.2/src/types.ts#L31) | The options that will be passed to the URL builder |
 
 ### `Picture`
 
-| property      | type | description |
-| ------------- | ---- | ----------- |
-| `client`      | [`SanityClient`](https://www.npmjs.com/package/@sanity/client) | Client instance to use when building image URLs |
-| `image`       | [`SanityImageSource`](https://www.npmjs.com/package/@sanity/image-url#imagesource) | A reference to a Sanity image asset. You can pass in any asset that is also supported by the [image() method of @sanity/image-url](https://www.npmjs.com/package/@sanity/image-url#imagesource). |
-| `aspectRatio` | <code>number &#124; null<code> | Aspect ratio (`height ÷ width`) to which the source image should be cropped **for the default source**, i.e. if no media conditions match. If omitted or set to `null`, the intrinsic aspect ratio of the source will be used. |
-| `lqip`        | `boolean`| Set to `true` to use the image's [Low Quality Image Placeholder](https://www.sanity.io/docs/image-metadata#74bfd1db9b97) as a placeholder |
-| `media`       | `[{ media: string, aspectRatio: number }]` | Specify an array of media conditions and aspect ratios which will be used to render `<source>` elements in the resulting `<picture>`. Order of items matters (the browser will use the first match it encounters). See example in **Usage** above. |
-| `sizes`       | `string` | String to use for the rendered `<img>` element's [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) attribute. See example in **Usage** above. |
-| `imgProps`    | `object` | Any extra props to pass through to the rendered `<img>` element |
+| property         | type | description |
+| ---------------- | ---- | ----------- |
+| `client`         | [`SanityClient`](https://www.npmjs.com/package/@sanity/client) | Client instance to use when building image URLs |
+| `image`          | [`SanityImageSource`](https://www.npmjs.com/package/@sanity/image-url#imagesource) | A reference to a Sanity image asset. You can pass in any asset that is also supported by the [image() method of @sanity/image-url](https://www.npmjs.com/package/@sanity/image-url#imagesource). |
+| `aspectRatio`    | <code>number &#124; null<code> | Aspect ratio (`height ÷ width`) to which the source image should be cropped **for the default source**, i.e. if no media conditions match. If omitted or set to `null`, the intrinsic aspect ratio of the source will be used. |
+| `lqip`           | `boolean`| Set to `true` to use the image's [Low Quality Image Placeholder](https://www.sanity.io/docs/image-metadata#74bfd1db9b97) as a placeholder |
+| `media`          | `[{ media: string, aspectRatio: number }]` | Specify an array of media conditions and aspect ratios which will be used to render `<source>` elements in the resulting `<picture>`. Order of items matters (the browser will use the first match it encounters). See example in **Usage** above. |
+| `sizes`          | `string` | String to use for the rendered `<img>` element's [`sizes`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) attribute. See example in **Usage** above. |
+| `imgProps`       | `object` | Any extra props to pass through to the rendered `<img>` element |
+| `builderOptions` | [`ImageUrlBuilderOptionsWithAliases`](https://github.com/sanity-io/image-url/blob/v1.0.2/src/types.ts#L31) | The options that will be passed to the URL builder |
 
 ## Creating a new version for npm
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Assuming you've already queried a document from Sanity that includes an image fi
     image={person.image}
 />
 
-// Specifying aspect ratio and `sizes` attribute, and enabling `lqip`
+// Passing options to the URL builder
 <Img
     client={client}
     image={person.image}

--- a/README.md
+++ b/README.md
@@ -46,11 +46,20 @@ const client = sanityClient({
 
 Assuming you've already queried a document from Sanity that includes an image field (there's an example [here](https://www.sanity.io/docs/presenting-images#BnS1mFRw); let's say it's `person` and the field is `person.image`), render the `Img` component like this:
 
-```js
+```jsx
 // Basic usage at intrinsic aspect ratio
 <Img
     client={client}
     image={person.image}
+/>
+
+// Specifying aspect ratio and `sizes` attribute, and enabling `lqip`
+<Img
+    client={client}
+    image={person.image}
+    builderOptions={{
+        blur: 50
+    }}
 />
 
 // Specifying aspect ratio and `sizes` attribute, and enabling `lqip`
@@ -73,7 +82,7 @@ Assuming you've already queried a document from Sanity that includes an image fi
 
 The `Picture` component is similar but supports an additional `media` prop for adding extra sources:
 
-```js
+```jsx
 <Picture
     client={client}
     image={person.image}
@@ -86,13 +95,25 @@ The `Picture` component is similar but supports an additional `media` prop for a
 />
 ```
 
+It also supports `builderOptions` which will be applied to all URLs that are created:
+
+```jsx
+<Picture
+    client={client}
+    image={person.image}
+    builderOptions={{
+        blur: 50
+    }}
+/>
+```
+
 Order of `media` items matters the same way ordering `source` elements inside `<picture>` matters (i.e. the browser will use the first match that it encounters).
 
 Sanity's CDN will automatically serve WebP format images to browsers that support them, so there's no need to include any extra sources for these (you can't specify the `type` attribute at the moment anyway).
 
 Finally, any extra props passed to `Picture` **will be set on the rendered `<picture>` element**. If you want to specify extra props for the `<img>` element inside it, use `imgProps`:
 
-```js
+```jsx
 <Picture
     client={client}
     image={person.image}
@@ -115,7 +136,7 @@ $ nvm use  # `nvm install` if necessary
 $ npm install
 ```
 
-Storybook is included to facilitate local development and testing. You'll need to configure a connection to a Sanity project from which an image asset can be retreived for use in stories.
+Storybook is included to facilitate local development and testing. You'll need to configure a connection to a Sanity project from which an image asset can be retrieved for use in stories.
 
 Copy the included `.env.example` file to `.env` and edit it to add your project details and the ID of an asset to fetch. You can find one by querying `imageAsset` documents within your project (`*[_type == "sanity.imageAsset"]`).
 

--- a/src/components/Img/index.tsx
+++ b/src/components/Img/index.tsx
@@ -8,6 +8,7 @@ import {
 import type {
     SanityClientLike,
     SanityImageObject,
+    BuilderOptions,
 } from '../../types';
 
 export interface BaseImgProps {
@@ -16,15 +17,16 @@ export interface BaseImgProps {
     aspectRatio?: number,
     lqip?: boolean,
     sizes?: string,
+    builderOptions?: BuilderOptions,
 }
 
 export type ImgProps = BaseImgProps & React.ImgHTMLAttributes<HTMLImageElement>;
 
-export const Img = ({ client, image, aspectRatio, lqip, sizes, ...rest }: ImgProps) => (
+export const Img = ({ client, image, aspectRatio, lqip, sizes, builderOptions = undefined, ...rest }: ImgProps) => (
     <img
-        srcSet={getSrcSet(client, image, aspectRatio)}
+        srcSet={getSrcSet(client, image, aspectRatio, builderOptions)}
         sizes={sizes}
-        src={getSrc(client, image, aspectRatio)}
+        src={getSrc(client, image, aspectRatio, builderOptions)}
         style={lqip ? getLqipBackgroundStyle(image) : {}}
         {...getDefaultSize(image, aspectRatio)}
         {...rest}

--- a/src/components/Img/stories.tsx
+++ b/src/components/Img/stories.tsx
@@ -18,20 +18,6 @@ const params = { assetId: process.env.SANITY_ASSET_ID };
 export default {
     title: 'Img',
     component: Img,
-    args: {
-        builderOptions: {
-            blur: undefined,
-            sharpen: undefined,
-            format: undefined,
-            invert: undefined,
-            orientation: undefined,
-            quality: undefined,
-            fit: undefined,
-            crop: undefined,
-            saturation: undefined,
-            auto: undefined,
-        }
-    }
 } as ComponentMeta<typeof Img>;
 
 const Template: ComponentStory<typeof Img> = (args, { loaded: { image }}) => {
@@ -52,6 +38,36 @@ Default.loaders = Template.loaders;
 export const WithCropping = Template.bind({});
 WithCropping.args = {};
 WithCropping.loaders = [
+    async () => ({
+        image: {
+            asset: (await client.fetch(query, params)) as Promise<SanityAsset>,
+            crop: {
+                _type: "sanity.imageCrop",
+                bottom: 0,
+                left: 0,
+                right: 0,
+                top: 0.5,
+            },
+        },
+    }),
+];
+
+export const WithBuilderOptions = Template.bind({});
+WithBuilderOptions.args = {
+    builderOptions: {
+        blur: undefined,
+        sharpen: undefined,
+        format: undefined,
+        invert: undefined,
+        orientation: 90,
+        quality: undefined,
+        fit: undefined,
+        crop: undefined,
+        saturation: undefined,
+        auto: undefined,
+    },
+};
+WithBuilderOptions.loaders = [
     async () => ({
         image: {
             asset: (await client.fetch(query, params)) as Promise<SanityAsset>,

--- a/src/components/Img/stories.tsx
+++ b/src/components/Img/stories.tsx
@@ -18,6 +18,20 @@ const params = { assetId: process.env.SANITY_ASSET_ID };
 export default {
     title: 'Img',
     component: Img,
+    args: {
+        builderOptions: {
+            blur: undefined,
+            sharpen: undefined,
+            format: undefined,
+            invert: undefined,
+            orientation: undefined,
+            quality: undefined,
+            fit: undefined,
+            crop: undefined,
+            saturation: undefined,
+            auto: undefined,
+        }
+    }
 } as ComponentMeta<typeof Img>;
 
 const Template: ComponentStory<typeof Img> = (args, { loaded: { image }}) => {

--- a/src/components/Picture/index.tsx
+++ b/src/components/Picture/index.tsx
@@ -14,21 +14,17 @@ export interface BasePictureProps {
 export type PictureProps =
     BaseImgProps & BasePictureProps & React.HTMLAttributes<HTMLPictureElement>;
 
-export const Picture = ({ client, image, aspectRatio, lqip, media = [], sizes, imgProps, ...rest }: PictureProps) => (
+export const Picture = ({ client, image, aspectRatio, lqip, media = [], sizes, builderOptions = undefined, imgProps, ...rest }: PictureProps) => (
     <picture {...rest}>
         {media.map(({ media, aspectRatio }) => (
             <source
                 key={media}
                 media={media}
-                srcSet={getSrcSet(client, image, aspectRatio)}
+                srcSet={getSrcSet(client, image, aspectRatio, builderOptions)}
             />
         ))}
         <Img
-            client={client}
-            image={image}
-            aspectRatio={aspectRatio}
-            lqip={lqip}
-            sizes={sizes}
+            {...{ client, image, aspectRatio, lqip, sizes, builderOptions }}
             {...imgProps}
         />
     </picture>

--- a/src/components/Picture/stories.tsx
+++ b/src/components/Picture/stories.tsx
@@ -19,6 +19,24 @@ const params = { assetId: process.env.SANITY_ASSET_ID };
 export default {
     title: 'Picture',
     component: Picture,
+    args: {
+        builderOptions: {
+            blur: undefined,
+            sharpen: undefined,
+            format: undefined,
+            invert: undefined,
+            orientation: undefined,
+            quality: undefined,
+            fit: undefined,
+            crop: undefined,
+            saturation: undefined,
+            auto: undefined,
+        },
+        media:[{
+            media: '(min-width: 1024px)',
+            aspectRatio: 9/16,
+        }]
+    }
 } as ComponentMeta<typeof Picture>;
 
 const Template: ComponentStory<typeof Picture> = (args, { loaded: { image } }) => {

--- a/src/components/Picture/stories.tsx
+++ b/src/components/Picture/stories.tsx
@@ -19,24 +19,6 @@ const params = { assetId: process.env.SANITY_ASSET_ID };
 export default {
     title: 'Picture',
     component: Picture,
-    args: {
-        builderOptions: {
-            blur: undefined,
-            sharpen: undefined,
-            format: undefined,
-            invert: undefined,
-            orientation: undefined,
-            quality: undefined,
-            fit: undefined,
-            crop: undefined,
-            saturation: undefined,
-            auto: undefined,
-        },
-        media:[{
-            media: '(min-width: 1024px)',
-            aspectRatio: 9/16,
-        }]
-    }
 } as ComponentMeta<typeof Picture>;
 
 const Template: ComponentStory<typeof Picture> = (args, { loaded: { image } }) => {
@@ -53,3 +35,24 @@ Template.loaders = [
 export const Default = Template.bind({});
 Default.args = {};
 Default.loaders = Template.loaders;
+
+export const WithOptionsAndMedia = Template.bind({});
+WithOptionsAndMedia.args = {
+    builderOptions: {
+        blur: undefined,
+        sharpen: undefined,
+        format: undefined,
+        invert: true,
+        orientation: undefined,
+        quality: undefined,
+        fit: undefined,
+        crop: undefined,
+        saturation: undefined,
+        auto: undefined,
+    },
+    media:[{
+        media: '(min-width: 1024px)',
+        aspectRatio: 9/16,
+    }]
+};
+WithOptionsAndMedia.loaders = Template.loaders;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export type {
 
 export { default as Img } from "./components/Img";
 export { default as Picture } from "./components/Picture";
-export { SOURCE_WIDTHS } from "./utils";
+export { DEFAULT_SOURCE_WIDTHS } from "./utils";
 
 // Legacy constant name for backwards-compatibility
-export { SOURCE_WIDTHS as IMAGE_WIDTHS } from "./utils";
+export { DEFAULT_SOURCE_WIDTHS as IMAGE_WIDTHS } from "./utils";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
-import { SanityImageObject as _SanityImageObject } from '@sanity/image-url/lib/types/types';
+import { ImageUrlBuilderOptionsWithAliases, SanityImageObject as _SanityImageObject } from '@sanity/image-url/lib/types/types';
 
-export type { SanityAsset, SanityClientLike } from '@sanity/image-url/lib/types/types';
+export type { SanityAsset, SanityClientLike, ImageUrlBuilderOptionsWithAliases } from '@sanity/image-url/lib/types/types';
+
+export type BuilderOptions = ImageUrlBuilderOptionsWithAliases & { sourceWidths?: number[] };
 
 export interface SanityImageObject extends _SanityImageObject {
     type?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,11 +10,11 @@ export const DEFAULT_SOURCE_WIDTHS = [320, 640, 960, 1280, 1600, 1920, 2240];
 /**
  * The fallback quality that will be used when none is provided.
  */
-export const DEFAULT_FALLBACK_IMAGE_QUALITY = 90;
+export const DEFAULT_IMAGE_QUALITY = 90;
 
 export const DEFAULT_BUILDER_OPTIONS: BuilderOptions = {
   auto: 'format',
-  quality: DEFAULT_FALLBACK_IMAGE_QUALITY,
+  quality: DEFAULT_IMAGE_QUALITY,
   sourceWidths: DEFAULT_SOURCE_WIDTHS,
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,32 @@
 import imageUrlBuilder from '@sanity/image-url';
 
-import { SanityClientLike, SanityImageObject } from './types';
+import { SanityClientLike, SanityImageObject, ImageUrlBuilderOptionsWithAliases, BuilderOptions } from './types';
 
 /**
  * Various widths at which to generate image sources in `srcset`. First item is used as the default width in fallback `img` elements.
  */
-export const SOURCE_WIDTHS = [320, 640, 960, 1280, 1600, 1920, 2240];
+export const DEFAULT_SOURCE_WIDTHS = [320, 640, 960, 1280, 1600, 1920, 2240];
 
 /**
- * Get dimensions of the specified image at the default size, which is a `width` of the first element in `SOURCE_WIDTHS` and a corresponding `height` based on cropped or default aspect ratio, overrideable with the `aspectRatio` argument
+ * The fallback quality that will be used when none is provided.
+ */
+export const DEFAULT_FALLBACK_IMAGE_QUALITY = 90;
+
+export const DEFAULT_BUILDER_OPTIONS: BuilderOptions = {
+  auto: 'format',
+  quality: DEFAULT_FALLBACK_IMAGE_QUALITY,
+  sourceWidths: DEFAULT_SOURCE_WIDTHS,
+};
+
+/**
+ * Get dimensions of the specified image at the default size, which is a `width` of the first element in `DEFAULT_SOURCE_WIDTHS` and a corresponding `height` based on cropped or default aspect ratio, overrideable with the `aspectRatio` argument
  * @param image Sanity image object
  * @param aspectRatio Desired aspect ratio
  * @returns Dimensions object containing `width` and `height`
  */
-export const getDefaultSize = (image: SanityImageObject, aspectRatio?: number) => {
+export const getDefaultSize = (image: SanityImageObject, aspectRatio?: number, sourceWidths = DEFAULT_SOURCE_WIDTHS) => {
     const finalAspectRatio = aspectRatio || getEffectiveAspectRatio(image);
-    const width = SOURCE_WIDTHS[0];
+    const width = sourceWidths[0];
     const height = Math.round(finalAspectRatio * width);
     return { width, height };
 };
@@ -78,37 +89,37 @@ export const getLqipBackgroundStyle = (image: SanityImageObject) => image.asset.
  * @param client Sanity client instance
  * @param image Sanity image object
  * @param aspectRatio Desired aspect ratio of generated sources
+ * @param options The image builder options to use
  * @returns `srcset` string
  */
-export const getSrcSet = (client: SanityClientLike, image: SanityImageObject, aspectRatio?: number) => {
+export const getSrcSet = (client: SanityClientLike, image: SanityImageObject, aspectRatio?: number, options?: ImageUrlBuilderOptionsWithAliases) => {
     const { width: effectiveWidth } = getEffectiveDimensions(image);
     const finalAspectRatio = aspectRatio || getEffectiveAspectRatio(image);
-    return SOURCE_WIDTHS.map(width => {
+    const imageOptions = { ...DEFAULT_BUILDER_OPTIONS, ...options };
+    return (imageOptions.sourceWidths || DEFAULT_SOURCE_WIDTHS).map(width => {
         const height = Math.round(finalAspectRatio * width);
         return width <= effectiveWidth
-            ? `${getUrl(client, image, width, height)} ${width}w`
+            ? `${getUrl(client, image, { width, height, ...imageOptions })} ${width}w`
             : undefined;
     }).filter(s => s).join(', ');
 };
 
-export const getSrc = (client: SanityClientLike, image: SanityImageObject, aspectRatio?: number) => {
-    const { width, height } = getDefaultSize(image, aspectRatio);
-    return getUrl(client, image, width, height);
+export const getSrc = (client: SanityClientLike, image: SanityImageObject, aspectRatio?: number, options?: ImageUrlBuilderOptionsWithAliases) => {
+    const imageOptions = { ...DEFAULT_BUILDER_OPTIONS, ...options };
+    const { width, height } = getDefaultSize(image, aspectRatio, imageOptions.sourceWidths);
+    return getUrl(client, image, { width, height, ...options });
 };
 
 /**
  * Use the Sanity image-url builder to construct a CDN URL for the given image at the given dimensions
  * @param client Sanity client instance
  * @param image Sanity image object
- * @param width Image width in pixels
- * @param height Image height in pixels
+ * @param options ImageUrlBuilderOptionsWithAliases builder options
  * @returns CDN URL for generated image
  */
- export const getUrl = (client: SanityClientLike, image: SanityImageObject, width: number, height: number) => {
+ export const getUrl = (client: SanityClientLike, image: SanityImageObject, options: ImageUrlBuilderOptionsWithAliases) => {
     const builder = imageUrlBuilder(client);
-    return builder.image(image)
-                  .width(width)
-                  .height(height)
-                  .auto('format')
+    return builder.withOptions(options)
+                  .image(image)
                   .url();
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,7 +107,7 @@ export const getSrcSet = (client: SanityClientLike, image: SanityImageObject, as
 export const getSrc = (client: SanityClientLike, image: SanityImageObject, aspectRatio?: number, options?: ImageUrlBuilderOptionsWithAliases) => {
     const imageOptions = { ...DEFAULT_BUILDER_OPTIONS, ...options };
     const { width, height } = getDefaultSize(image, aspectRatio, imageOptions.sourceWidths);
-    return getUrl(client, image, { width, height, ...options });
+    return getUrl(client, image, { width, height, ...imageOptions });
 };
 
 /**


### PR DESCRIPTION
This change allows passing `builderOptions` and `sourceWidths` though to the image builder. This means you can modify the image using a simple object.

I updated the storybook as well to show the demo of the changes